### PR TITLE
Fix: handle multi-digit events

### DIFF
--- a/record.c
+++ b/record.c
@@ -78,7 +78,7 @@ static void open_input_devices_proc(int epollfd)
 		if(!strncmp(buf, "H: Handlers=", len)){
 			char *token = NULL;
 			bool kbd = false;
-			int event = -1;
+			char *event = NULL;
 
 			buf[strlen(buf)-1] = '\0';
 			token = strtok(buf+len, " ");
@@ -86,12 +86,12 @@ static void open_input_devices_proc(int epollfd)
 				if(!strcmp(token, "kbd")){
 					kbd = true;
 				}else if(!strncmp(token, "event", strlen("event"))){
-					event = token[strlen("event")]-'0';
+					event = strdup(token);
 				}
 				token = strtok(NULL, " ");
 			}
-			if(kbd && event != -1){
-				snprintf(buf, sizeof(buf), "/dev/input/event%d", event);
+			if(kbd && event != NULL){
+				snprintf(buf, sizeof(buf), "/dev/input/%s", event);
 				add_to_epoll(epollfd, buf);
 				have_kbd = true;
 			}


### PR DESCRIPTION
Thank you for the project! Just a simple and useful application.

I fixed a bug where the code didn't correctly handle files like this:

```
/dev/input/event17
```

It used `event1` instead of `event17`. Now it works just fine.

It was very long ago since I wrote some C code, so take my changes with a grain of salt please.